### PR TITLE
Specify path, lineno on evaling first file

### DIFF
--- a/lib/roadworker/dsl.rb
+++ b/lib/roadworker/dsl.rb
@@ -2,9 +2,9 @@ module Roadworker
   class DSL
 
     class << self
-      def define(source, path)
+      def define(source, path, lineno = 1)
         self.new(path) do
-          eval(source, binding)
+          eval(source, binding, path, lineno)
         end
       end
 


### PR DESCRIPTION
Features depend on filepath+lineno (such as `__FILE__`, `__dir__`) didn't work 
because they were not set when evaluating a file content.