### PR TITLE
allow elb name with dualstack

### DIFF
--- a/lib/roadworker/route53-ext.rb
+++ b/lib/roadworker/route53-ext.rb
@@ -68,6 +68,13 @@ module Aws
         else
           elb = Aws::ElasticLoadBalancing::Client.new(:region => region)
 
+          if ( name =~ /^dualstack\./ )
+            name = name.sub( /^dualstack\./, '' )
+            pre_elb_name = 'dualstack.'
+          else
+            pre_elb_name = ''
+          end
+
           load_balancer = nil
           elb.describe_load_balancers.each do |page|
             page.load_balancer_descriptions.each do |lb|
@@ -84,7 +91,7 @@ module Aws
 
           {
             :hosted_zone_id         => load_balancer.canonical_hosted_zone_name_id,
-            :dns_name               => load_balancer.dns_name,
+            :dns_name               => pre_elb_name + load_balancer.dns_name,
             :evaluate_target_health => false, # XXX:
           }
         end


### PR DESCRIPTION
Roadworker をいつも使用させていただいております。

Roadworker を使ってELBへのエイリアスをDNSレコードを追加する際に、「dualstack.」が付いているとELBの存在チェックに引っかかりエラーになります。
マネジメントコンソールでDNSレコードにELBのエンドポイントを追加すると「dualstack.」が付加されるので、Roadworker も対応していただくリクエストしました。

ご検討よろしくお願いします。

------------------------------------------------------------------
dualstack. in dns_name to Error.
ex. "dualstack.your-elb-name.ap-northeast-1.elb.amazonaws.com."

It has been corrected to allow elb name with dualstack.