### PR TITLE
Support multiple private zones w/ same zone name

### DIFF
--- a/bin/roadwork
+++ b/bin/roadwork
@@ -111,7 +111,8 @@ begin
       client.export do |exported, converter|
         exported[:hosted_zones].each do |zone|
           route_file_basename = zone[:name].sub(/\.\Z/, '')
-          route_file_basename << '.private' unless zone[:vpcs].empty?
+          route_file_basename << ".private" unless zone[:vpcs].empty?
+          route_file_basename << ".#{zone[:vpcs].first.vpc_id}" unless zone[:vpcs].empty?
           route_file_basename << '.route'
 
           route_file = File.join(File.dirname(output_file), route_file_basename)


### PR DESCRIPTION
Multiple private zones with the same zone name (i.e. for testing, staging,
production) are exported to the same file when using the `--split`
option.

By adding the `vpc_id` to the `route_file_basename`, multiple private
zones with the same zone name can be correctly exported to separate
files when using the `--split` option.