### PR TITLE
Remove bad character from wildcard's rand_str

### DIFF
--- a/lib/roadworker/dsl-tester.rb
+++ b/lib/roadworker/dsl-tester.rb
@@ -298,7 +298,7 @@ module Roadworker
       end
 
       def asterisk_to_anyname(name)
-        rand_str = (("a".."z").to_a + ("A".."z").to_a + (0..9).to_a).shuffle[0..7].join
+        rand_str = (("a".."z").to_a + ("A".."Z").to_a + (0..9).to_a).shuffle[0..7].join
         name.gsub('*', "#{ASTERISK_PREFIX}-#{rand_str}")
       end
 


### PR DESCRIPTION
`("A".."z").to_a` contains "[", "\\", "]", "^", "_", "`". 
These characers are bad for net/dns.

I get an error such as the following
`asterisk-of-wildcard-clP^sa6].hoge.jp. A: Bad query string`

Thanks! nice work.