### PR TITLE
Support ignoring rrsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,20 @@ hosted_zone "winebarrel.jp." do
 end
 ```
 
+### Exclude specific records from management under Roadworker
+
+Use this if your zone contains rrsets managed by other tools, and you want to ignore them in Roadworker.
+
+```ruby
+hosted_zone "winebarrel.jp." do
+  ignore "ignore.winebarrel.jp"
+  ignore /^regexp-ignore/
+
+  # *.ignore2.winebarrel.jp and ignore2.winebarrel.jp
+  ignore_under "ignore2.winebarrel.jp"
+end
+```
+
 ## Test
 
 Routefile compares the results of a query to the DNS and DSL in the test mode.

--- a/lib/roadworker/client.rb
+++ b/lib/roadworker/client.rb
@@ -122,6 +122,13 @@ module Roadworker
           actual_record = actual.delete([name, actual_type, set_identifier])
         end
 
+        if expected_zone.ignore_patterns.any? { |pattern| pattern === name }
+          log(:warn, "Ignoring defined record in DSL, because it is ignored record", :yellow) do
+            "#{name} #{type}" + (set_identifier ? " (#{set_identifier})" : '')
+          end
+          next
+        end
+
         if actual_record
           unless actual_record.eql?(expected_record)
             actual_record.update(expected_record)
@@ -132,6 +139,11 @@ module Roadworker
       end
 
       actual.each do |keys, record|
+        name = keys[0]
+        if expected_zone.ignore_patterns.any? { |pattern| pattern === name }
+          next
+        end
+        
         record.delete
       end
     end

--- a/lib/roadworker/dsl.rb
+++ b/lib/roadworker/dsl.rb
@@ -68,6 +68,7 @@ module Roadworker
           :vpcs => [],
           :resource_record_sets => rrsets,
           :rrsets => rrsets,
+          :ignore_patterns => [],
         })
 
         instance_eval(&block)
@@ -91,6 +92,19 @@ module Roadworker
         end
 
         @result.vpcs << vpc_h
+      end
+
+      def ignore(rrset_name)
+        @result.ignore_patterns << case rrset_name
+        when Regexp
+          rrset_name
+        else 
+          rrset_name.to_s.sub(/\.\z/, '')
+        end
+      end
+
+      def ignore_under(rrset_name)
+        ignore /(\A|\.)#{Regexp.escape(rrset_name.to_s.sub(/\.\z/, ''))}\z/
       end
 
       def resource_record_set(rrset_name, type, &block)

--- a/spec/roadworker_create_spec.rb
+++ b/spec/roadworker_create_spec.rb
@@ -774,5 +774,50 @@ EOS
         expect(rrs_list(a3.resource_records.sort_by {|i| i.to_s })).to eq(["127.0.0.1", "127.0.0.2"])
       }
     end
+
+    context 'ignored record' do
+      it {
+        routefile do
+<<EOS
+hosted_zone "winebarrel.jp" do
+  ignore_under "ignore.winebarrel.jp"
+
+  rrset "ignore.winebarrel.jp", "A" do
+    ttl 60
+    resource_records(
+      "127.0.0.1",
+    )
+  end
+
+  rrset "test.ignore.winebarrel.jp", "A" do
+    ttl 60
+    resource_records(
+      "127.0.0.1",
+    )
+  end
+
+  rrset "not-ignore.winebarrel.jp", "A" do
+    ttl 60
+    resource_records(
+      "127.0.0.1",
+    )
+  end
+end
+EOS
+        end
+
+        zones = fetch_hosted_zones(@route53)
+        expect(zones.length).to eq(1)
+
+        zone = zones[0]
+        expect(zone.name).to eq("winebarrel.jp.")
+
+        rrsets = fetch_rrsets(@route53, zone.id)
+        expect(rrsets['ignore.winebarrel.jp.', 'A']).to be_nil
+        expect(rrsets['test.ignore.winebarrel.jp.', 'A']).to be_nil
+        expect(rrsets['not-ignore.winebarrel.jp.', 'A']).not_to be_nil
+      }
+    end
+
   end
 end


### PR DESCRIPTION
Adding new DSL methods for hosted zone: `ignore`, `ignore_under`.

Both allow excluding rrset matches against defined patterns from management of Roadworker. If An actual rrset's name matches against a defined pattern, Roadworker ignores them even if it's different from DSL.

This will be useful some rrsets are managed under other tools or scripts in a same hosted zone; because current Route 53 doesn't allow associating nested private hosted zone in a same VPC.

``` ruby
hosted_zone "winebarrel.jp." do
  ignore "ignore.winebarrel.jp"
  ignore /^regexp-ignore/

  # *.ignore2.winebarrel.jp and ignore2.winebarrel.jp
  ignore_under "ignore2.winebarrel.jp"
end
```