### PR TITLE
Fixed export with GeoLocation

### DIFF
--- a/lib/roadworker/dsl-converter.rb
+++ b/lib/roadworker/dsl-converter.rb
@@ -67,9 +67,12 @@ module Roadworker
                 "#{key} #{value}"
               end
             else
-              inspected_value = value.inspect
-              inspected_value.sub!(/\A{/, '').sub!(/}\z/, '') if value.kind_of?(Hash)
-              "#{key} #{inspected_value}"
+              if value.kind_of?(Aws::Route53::Types::GeoLocation)
+                replaced_value = value.to_h.to_s.sub!(/\A{/, '').sub!(/}\z/, '')
+                "#{key} #{replaced_value}"
+              else
+                "#{key} #{value.inspect}"
+              end
             end
           }.select {|i| i }.join("\n    ")
 


### PR DESCRIPTION
Hi Sugawara-san !
Thank you for awesome tools.

# BEFORE

I found that `GeoLocation` export does not work like this.

```ruby
rrset "hoge.example.com.", "A" do
  set_identifier "1234"
  ttl 300
  geo_location #<struct Aws::Route53::Types::GeoLocation continent_code="AF", country_code=nil, subdivision_code=nil>
  resource_records(
    "127.0.0.1"
  )
end
```

I think that this is `output_rrset` problem.
`value` is `Aws::Route53::Types::GeoLocation` object not `Hash` in `output_rrset`.

# AFTER

```ruby
rrset "hoge.example.com.", "A" do
  set_identifier "1234"
  ttl 300
  geo_location :continent_code=>"AF"
  resource_records(
    "127.0.0.1"
  )
end
```

# RELATED PR

- https://github.com/winebarrel/roadworker/pull/15

# FINALLY

This is my just idea, so "close PR" is OK.
Please review if PR has side-effect.

Thanks 🙇 